### PR TITLE
 Added Dichroic Feature to Mirror Segment Objects

### DIFF
--- a/simulator/js/canvasPainter.js
+++ b/simulator/js/canvasPainter.js
@@ -16,7 +16,7 @@ var canvasPainter = {
     else if (graph.type == 2) {
       ctx.strokeStyle = color ? color : 'black';
       ctx.beginPath();
-      var ang1 = Math.atan2((graph.p2.x - graph.p1.x), (graph.p2.y - graph.p1.y)); //從斜率取得角度 Get the angle from the slope Get the angle from the slope Get the angle from the slope
+      var ang1 = Math.atan2((graph.p2.x - graph.p1.x), (graph.p2.y - graph.p1.y)); //從斜率取得角度 Get the angle from the slope 
       var cvsLimit = (Math.abs(graph.p1.x + origin.x) + Math.abs(graph.p1.y + origin.y) + canvas.height + canvas.width) / Math.min(1, scale);  //取一個會超出繪圖區的距離(當做直線端點) Choose a distance exceeding the edge of the drawing area (for the endpoint of the line) Choose a distance exceeding the edge of the drawing area (for the endpoint of the line)
       ctx.moveTo(graph.p1.x - Math.sin(ang1) * cvsLimit, graph.p1.y - Math.cos(ang1) * cvsLimit);
       ctx.lineTo(graph.p1.x + Math.sin(ang1) * cvsLimit, graph.p1.y + Math.cos(ang1) * cvsLimit);
@@ -29,7 +29,7 @@ var canvasPainter = {
       if (Math.abs(graph.p2.x - graph.p1.x) > 1e-5 || Math.abs(graph.p2.y - graph.p1.y) > 1e-5)
       {
         ctx.beginPath();
-        ang1 = Math.atan2((graph.p2.x - graph.p1.x), (graph.p2.y - graph.p1.y)); //從斜率取得角度 Get the angle from the slope Get the angle from the slope
+        ang1 = Math.atan2((graph.p2.x - graph.p1.x), (graph.p2.y - graph.p1.y)); //從斜率取得角度 Get the angle from the slope 
         cvsLimit = (Math.abs(graph.p1.x + origin.x) + Math.abs(graph.p1.y + origin.y) + canvas.height + canvas.width) / Math.min(1, scale);  //取一個會超出繪圖區的距離(當做直線端點) Choose a distance exceeding the edge of the drawing area (for the endpoint of the line)
         ctx.moveTo(graph.p1.x, graph.p1.y);
         ctx.lineTo(graph.p1.x + Math.sin(ang1) * cvsLimit, graph.p1.y + Math.cos(ang1) * cvsLimit);

--- a/simulator/js/objs/laser.js
+++ b/simulator/js/objs/laser.js
@@ -28,14 +28,8 @@ objTypes['laser'] = {
 
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {
-
-  if (colorMode) {
-    ctx.fillStyle = getMouseStyle(obj, wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1));
-    ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
-  } else {
-    ctx.fillStyle = getMouseStyle(obj, 'rgb(255,0,0)');
-    ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
-  }
+  ctx.fillStyle = getMouseStyle(obj, colorMode ? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(255,0,0)');
+  ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
   ctx.fillStyle = getMouseStyle(obj, 'rgb(255,0,0)');
   ctx.fillRect(obj.p2.x - 1.5, obj.p2.y - 1.5, 3, 3);
   },

--- a/simulator/js/objs/laser.js
+++ b/simulator/js/objs/laser.js
@@ -20,7 +20,7 @@ objTypes['laser'] = {
       obj.p = value;
     }, elem);
     if (colorMode) {
-      createNumberAttr(getMsg('wavelength'), 400, 700, 1, obj.wavelength || 532, function(obj, value) {
+      createNumberAttr(getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) {
         obj.wavelength = value;
       }, elem);
     }
@@ -30,7 +30,7 @@ objTypes['laser'] = {
   draw: function(obj, canvas) {
 
   if (colorMode) {
-    ctx.fillStyle = getMouseStyle(obj, wavelengthToColor(obj.wavelength || 532, 1));
+    ctx.fillStyle = getMouseStyle(obj, wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1));
     ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
   } else {
     ctx.fillStyle = getMouseStyle(obj, 'rgb(255,0,0)');
@@ -47,7 +47,7 @@ objTypes['laser'] = {
   ray1.brightness_s = 0.5 * (obj.p || 1);
   ray1.brightness_p = 0.5 * (obj.p || 1);
   if (colorMode) {
-    ray1.wavelength = obj.wavelength || 532;
+    ray1.wavelength = obj.wavelength || GREEN_WAVELENGTH;
   }
   ray1.gap = true;
   ray1.isNew = true;

--- a/simulator/js/objs/led.js
+++ b/simulator/js/objs/led.js
@@ -13,7 +13,7 @@ objTypes['led'] = {
       obj.brightness = value;
     }, elem);
     if (colorMode) {
-      createNumberAttr(getMsg('wavelength'), 380, 750, 1, obj.wavelength || 532, function(obj, value) {
+      createNumberAttr(getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) {
         obj.wavelength = value;
       }, elem);
     }
@@ -36,7 +36,7 @@ objTypes['led'] = {
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {
   if (colorMode) {
-    ctx.fillStyle = wavelengthToColor(obj.wavelength || 532, 1);
+    ctx.fillStyle = wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1);
     ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
     ctx.fillStyle = getMouseStyle(obj, 'rgb(255,255,255)');
     ctx.fillRect(obj.p1.x - 1.5, obj.p1.y - 1.5, 3, 3);
@@ -76,7 +76,7 @@ objTypes['led'] = {
     ray1.brightness_s = Math.min((obj.brightness || 0.5) / getRayDensity(), 1) * 0.5;
     ray1.brightness_p = Math.min((obj.brightness || 0.5) / getRayDensity(), 1) * 0.5;
     if (colorMode) {
-      ray1.wavelength = obj.wavelength || 532;
+      ray1.wavelength = obj.wavelength || GREEN_WAVELENGTH;
     }
     ray1.isNew = true;
     if (i == i0)

--- a/simulator/js/objs/led.js
+++ b/simulator/js/objs/led.js
@@ -35,15 +35,8 @@ objTypes['led'] = {
 
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {
-  if (colorMode) {
-    ctx.fillStyle = wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1);
-    ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
-    ctx.fillStyle = getMouseStyle(obj, 'rgb(255,255,255)');
-    ctx.fillRect(obj.p1.x - 1.5, obj.p1.y - 1.5, 3, 3);
-  } else {
-    ctx.fillStyle = getMouseStyle(obj, 'rgb(0,255,0)');
-    ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
-  }
+  ctx.fillStyle = getMouseStyle(obj, colorMode? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(0,255,0)');
+  ctx.fillRect(obj.p1.x - 2.5, obj.p1.y - 2.5, 5, 5);
   ctx.fillStyle = getMouseStyle(obj, 'rgb(255,0,0)');
   ctx.fillRect(obj.p2.x - 1.5, obj.p2.y - 1.5, 3, 3);
   },

--- a/simulator/js/objs/mirror.js
+++ b/simulator/js/objs/mirror.js
@@ -3,7 +3,7 @@ objTypes['mirror'] = {
 
   //建立物件 Create the obj
   create: function(mouse) {
-    return {type: 'mirror', p1: mouse, p2: mouse};
+    return {type: 'mirror', p1: mouse, p2: mouse, dichroic : false};
   },
 
   //使用lineobj原型 Use the prototype lineobj
@@ -17,7 +17,7 @@ objTypes['mirror'] = {
 
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {    
-    ctx.strokeStyle = getMouseStyle(obj, (colorMode && obj.wavelength) ? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(168,168,168)');
+    ctx.strokeStyle = getMouseStyle(obj, (colorMode && obj.wavelength && obj.dichroic) ? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(168,168,168)');
     ctx.beginPath();
     ctx.moveTo(obj.p1.x, obj.p1.y);
     ctx.lineTo(obj.p2.x, obj.p2.y);
@@ -27,9 +27,11 @@ objTypes['mirror'] = {
   //顯示屬性方塊 Show the property box
   p_box: function(obj, elem) {
     if (colorMode) {
-
+      createBooleanAttr(getMsg('dichroic'), obj.dichroic, function(obj, value) {
+          obj.dichroic = value;
+      }, elem);
       createNumberAttr(getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) { 
-        obj.wavelength = value;
+        obj.wavelength = obj.dichroic? value : NaN;
       }, elem);
     }
   },

--- a/simulator/js/objs/mirror.js
+++ b/simulator/js/objs/mirror.js
@@ -27,20 +27,10 @@ objTypes['mirror'] = {
   //顯示屬性方塊 Show the property box
   p_box: function(obj, elem) {
     if (colorMode) {
-      //var dichroic;
-      // if(dichroic){
-      createNumberAttr("Dichroic " + getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) { 
+
+      createNumberAttr(getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) { 
         obj.wavelength = value;
       }, elem);
-      // }
-    
-      // createBooleanAttr(/*getMsg('')*/"Dichroic", dichroic, function(obj, value) {
-      //   if (obj == objs[selectedObj]) {
-      //     dichroic = value;
-      //     localStorage.rayOpticsDichroic = value?"true":"false";
-      //     selectObj(selectedObj);
-      //   }
-      // }, elem);
     }
   },
 

--- a/simulator/js/objs/mirror.js
+++ b/simulator/js/objs/mirror.js
@@ -16,15 +16,35 @@ objTypes['mirror'] = {
   rayIntersection: objTypes['lineobj'].rayIntersection,
 
   //將物件畫到Canvas上 Draw the obj on canvas
-  draw: function(obj, canvas) {
-    ctx.strokeStyle = getMouseStyle(obj, 'rgb(168,168,168)');
+  draw: function(obj, canvas) {    
+    ctx.strokeStyle = getMouseStyle(obj, (colorMode && obj.wavelength) ? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(168,168,168)');
     ctx.beginPath();
     ctx.moveTo(obj.p1.x, obj.p1.y);
     ctx.lineTo(obj.p2.x, obj.p2.y);
     ctx.stroke();
   },
 
+  //顯示屬性方塊 Show the property box
+  p_box: function(obj, elem) {
+    if (colorMode) {
+      //var dichroic;
+      // if(dichroic){
+      createNumberAttr("Dichroic " + getMsg('wavelength'), UV_WAVELENGTH, INFRARED_WAVELENGTH, 1, obj.wavelength || GREEN_WAVELENGTH, function(obj, value) { 
+        obj.wavelength = value;
+      }, elem);
+      // }
+    
+      // createBooleanAttr(/*getMsg('')*/"Dichroic", dichroic, function(obj, value) {
+      //   if (obj == objs[selectedObj]) {
+      //     dichroic = value;
+      //     localStorage.rayOpticsDichroic = value?"true":"false";
+      //     selectObj(selectedObj);
+      //   }
+      // }, elem);
+    }
+  },
 
+  
 
   //當物件被光射到時 When the obj is shot by a ray
   shot: function(mirror, ray, rayIndex, rp) {
@@ -32,8 +52,14 @@ objTypes['mirror'] = {
     var ry = ray.p1.y - rp.y;
     var mx = mirror.p2.x - mirror.p1.x;
     var my = mirror.p2.y - mirror.p1.y;
-    ray.p1 = rp;
-    ray.p2 = graphs.point(rp.x + rx * (my * my - mx * mx) - 2 * ry * mx * my, rp.y + ry * (mx * mx - my * my) - 2 * rx * mx * my);
+    if(!(colorMode && mirror.wavelength && mirror.wavelength != ray.wavelength)){
+      ray.p1 = rp;
+      ray.p2 = graphs.point(rp.x + rx * (my * my - mx * mx) - 2 * ry * mx * my, rp.y + ry * (mx * mx - my * my) - 2 * rx * mx * my);
+    } 
+    else{
+      ray.p1 = rp;
+      ray.p2 = graphs.point(rp.x-rx, rp.y-ry);
+    }
   }
 
 };

--- a/simulator/js/objs/parallel.js
+++ b/simulator/js/objs/parallel.js
@@ -20,11 +20,8 @@ objTypes['parallel'] = {
   draw: function(obj, canvas) {
     //var ctx = canvas.getContext('2d');
     var a_l = Math.atan2(obj.p1.x - obj.p2.x, obj.p1.y - obj.p2.y) - Math.PI / 2;
-    if (colorMode) {
-      ctx.strokeStyle = getMouseStyle(obj, wavelengthToColor(obj.wavelength || 532, 1));
-    } else {
-      ctx.strokeStyle = getMouseStyle(obj, 'rgb(0,255,0)');
-    }
+    ctx.strokeStyle = getMouseStyle(obj, colorMode ? wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1) : 'rgb(0,255,0)');
+    
     ctx.lineWidth = 4;
     ctx.lineCap = 'butt';
     ctx.beginPath();
@@ -58,7 +55,7 @@ objTypes['parallel'] = {
       ray1.brightness_p = Math.min(obj.p / getRayDensity(), 1) * 0.5;
       ray1.isNew = true;
       if (colorMode) {
-        ray1.wavelength = obj.wavelength || 532;
+        ray1.wavelength = obj.wavelength || GREEN_WAVELENGTH;
       }
       if (i == 0)
       {

--- a/simulator/js/objs/radiant.js
+++ b/simulator/js/objs/radiant.js
@@ -26,16 +26,8 @@ objTypes['radiant'] = {
 
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {
-  if (colorMode) {
-    ctx.fillStyle = wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1);
-    ctx.fillRect(obj.x - 2.5, obj.y - 2.5, 5, 5);
-    ctx.fillStyle = getMouseStyle(obj, 'rgb(255,255,255)');
-    ctx.fillRect(obj.x - 1.5, obj.y - 1.5, 3, 3);
-  } else {
-    ctx.fillStyle = getMouseStyle(obj, 'rgb(0,255,0)');
-    ctx.fillRect(obj.x - 2.5, obj.y - 2.5, 5, 5);
-  }
-
+  ctx.fillStyle = getMouseStyle(obj, colorMode? 'rgb(255,255,255)' : 'rgb(0,255,0)');
+  ctx.fillRect(obj.x - 2.5, obj.y - 2.5, 5, 5);
   },
 
   //平移物件 Move the object

--- a/simulator/js/objs/radiant.js
+++ b/simulator/js/objs/radiant.js
@@ -27,7 +27,7 @@ objTypes['radiant'] = {
   //將物件畫到Canvas上 Draw the obj on canvas
   draw: function(obj, canvas) {
   if (colorMode) {
-    ctx.fillStyle = wavelengthToColor(obj.wavelength || 532, 1);
+    ctx.fillStyle = wavelengthToColor(obj.wavelength || GREEN_WAVELENGTH, 1);
     ctx.fillRect(obj.x - 2.5, obj.y - 2.5, 5, 5);
     ctx.fillStyle = getMouseStyle(obj, 'rgb(255,255,255)');
     ctx.fillRect(obj.x - 1.5, obj.y - 1.5, 3, 3);
@@ -85,7 +85,7 @@ objTypes['radiant'] = {
     ray1.brightness_p = Math.min(obj.p / getRayDensity(), 1) * 0.5;
     ray1.isNew = true;
     if (colorMode) {
-      ray1.wavelength = obj.wavelength || 532;
+      ray1.wavelength = obj.wavelength || GREEN_WAVELENGTH;
     }
     if (i == i0)
     {

--- a/simulator/js/simulator.js
+++ b/simulator/js/simulator.js
@@ -16,7 +16,7 @@ var minShotLength = 1e-6; //光線兩次作用的最短距離(小於此距離的
 var minShotLength_squared = minShotLength * minShotLength;
 var totalTruncation = 0;
 
-const UV_WAVELENGTH = 400;
+const UV_WAVELENGTH = 380;
 const VIOLET_WAVELENGTH = 420;
 const BLUE_WAVELENGTH = 460;
 const CYAN_WAVELENGTH = 500;

--- a/simulator/locales/de.js
+++ b/simulator/locales/de.js
@@ -287,6 +287,9 @@ locales["de"] = {
   "wavelength": {
     "message": "Wellenlänge (nm):"
   },
+  "dichroic": {
+    "message": "Dichroitische"
+  },
   "emissionangle": {
     "message": "Emissionswinkel (°):"
   },

--- a/simulator/locales/en.js
+++ b/simulator/locales/en.js
@@ -288,6 +288,9 @@ locales["en"] = {
   "wavelength": {
     "message": "Wavelength (nm):"
   },
+  "dichroic": {
+    "message": "Dichroic"
+  },
   "emissionangle": {
     "message": "Emission Angle (°):"
   },

--- a/simulator/locales/fr.js
+++ b/simulator/locales/fr.js
@@ -313,6 +313,9 @@ locales["fr"] = {
     "incomplete": true,
     "message": "Wavelength (nm):"
   },
+  "dichroic": {
+    "message": "Dichroïque"
+  },
   "emissionangle": {
     "incomplete": true,
     "message": "Emission Angle (°):"

--- a/simulator/locales/nl.js
+++ b/simulator/locales/nl.js
@@ -328,6 +328,9 @@ locales["nl"] = {
     "incomplete": true,
     "message": "Wavelength (nm):"
   },
+  "dichroic": {
+    "message": "Dichroïde"
+  },
   "emissionangle": {
     "incomplete": true,
     "message": "Emission Angle (°):"

--- a/simulator/locales/ru.js
+++ b/simulator/locales/ru.js
@@ -314,6 +314,9 @@ locales["ru"] = {
     "incomplete": true,
     "message": "Wavelength (nm):"
   },
+  "dichroic": {
+    "message": "Дихроик"
+  },
   "emissionangle": {
     "incomplete": true,
     "message": "Emission Angle (°):"

--- a/simulator/locales/template.js
+++ b/simulator/locales/template.js
@@ -380,6 +380,10 @@ locales["LOCALE_ID"] = {
     "incomplete": true,
     "message": "Wavelength (nm):"
   },
+  "dichroic": {
+    "incomplete": true,
+    "message": "Dichroic"
+  },
   "emissionangle": {
     "incomplete": true,
     "message": "Emission Angle (°):"

--- a/simulator/locales/zh_CN.js
+++ b/simulator/locales/zh_CN.js
@@ -288,6 +288,9 @@ locales["zh-CN"] = {
   "wavelength": {
     "message": "波长 (nm):"
   },
+  "dichroic": {
+    "message": "二色性"
+  },
   "emissionangle": {
     "message": "发射角 (°)："
   },

--- a/simulator/locales/zh_TW.js
+++ b/simulator/locales/zh_TW.js
@@ -288,6 +288,9 @@ locales["zh-TW"] = {
   "wavelength": {
     "message": "波長 (nm)："
   },
+  "dichroic": {
+    "message": "二色性"
+  },
   "emissionangle": {
     "message": "發射角 (°)："
   },


### PR DESCRIPTION
Added a dichroic feature to the mirror obj when in color mode that can be toggled on and off.
Changed UV back to 380 nm to better match human perception.
Added dichroic message definitions to all current languages.
Replaced numeric literals in light source definitions with the named constants defined in simulator js.
Reduced code duplication in lightsource objs thru the use of ternary assignment of color.
![Screenshot from 2023-01-23 19-49-12](https://user-images.githubusercontent.com/22029083/214444324-0817a57e-f41b-490c-ba84-ed10bd28bf87.png)
