### PR TITLE
Replace `polyfill.io`

### DIFF
--- a/cn/gallery/GRIN-slab.html
+++ b/cn/gallery/GRIN-slab.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/NL-simulation.html
+++ b/cn/gallery/NL-simulation.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/aplanatic-points.html
+++ b/cn/gallery/aplanatic-points.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/apparent-depth.html
+++ b/cn/gallery/apparent-depth.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/beam-directors.html
+++ b/cn/gallery/beam-directors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/beam-expanders.html
+++ b/cn/gallery/beam-expanders.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/bended-pencil.html
+++ b/cn/gallery/bended-pencil.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/black-cat-becomes-white.html
+++ b/cn/gallery/black-cat-becomes-white.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/branched-flow.html
+++ b/cn/gallery/branched-flow.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/broken-pencil.html
+++ b/cn/gallery/broken-pencil.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/camera-obscura.html
+++ b/cn/gallery/camera-obscura.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/caustics-from-a-reflective-sphere.html
+++ b/cn/gallery/caustics-from-a-reflective-sphere.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/chaff-countermeasure.html
+++ b/cn/gallery/chaff-countermeasure.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/chromatic-aberration.html
+++ b/cn/gallery/chromatic-aberration.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/chromatic-dispersion.html
+++ b/cn/gallery/chromatic-dispersion.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/compound-microscope.html
+++ b/cn/gallery/compound-microscope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/concave-lens.html
+++ b/cn/gallery/concave-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/concave-mirror-wearable-display.html
+++ b/cn/gallery/concave-mirror-wearable-display.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/convex-lens.html
+++ b/cn/gallery/convex-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/dichroic-rbg-splitter-and-combiner.html
+++ b/cn/gallery/dichroic-rbg-splitter-and-combiner.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
+++ b/cn/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/fresnel-lens.html
+++ b/cn/gallery/fresnel-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/gan-based-lcd-pixel.html
+++ b/cn/gallery/gan-based-lcd-pixel.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/hyperbolic-lens.html
+++ b/cn/gallery/hyperbolic-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/hyperbolic-mirror.html
+++ b/cn/gallery/hyperbolic-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/images-formed-by-two-mirrors.html
+++ b/cn/gallery/images-formed-by-two-mirrors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/inferior-mirage.html
+++ b/cn/gallery/inferior-mirage.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/internal-reflection.html
+++ b/cn/gallery/internal-reflection.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/interrogation-room.html
+++ b/cn/gallery/interrogation-room.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/keplerian-telescope.html
+++ b/cn/gallery/keplerian-telescope.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/lens-images.html
+++ b/cn/gallery/lens-images.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/logarithmic-spiral-lens.html
+++ b/cn/gallery/logarithmic-spiral-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/luneburg-lens.html
+++ b/cn/gallery/luneburg-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/maxwell-fisheye-lens.html
+++ b/cn/gallery/maxwell-fisheye-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/maze-solution.html
+++ b/cn/gallery/maze-solution.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/minimum-deviation-angle.html
+++ b/cn/gallery/minimum-deviation-angle.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/monochromatic-aberrations.html
+++ b/cn/gallery/monochromatic-aberrations.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/newtonian-telescope.html
+++ b/cn/gallery/newtonian-telescope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/optical-cavity.html
+++ b/cn/gallery/optical-cavity.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/parabolic-mirror.html
+++ b/cn/gallery/parabolic-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/penrose-unilluminable-room.html
+++ b/cn/gallery/penrose-unilluminable-room.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/periscope.html
+++ b/cn/gallery/periscope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/prisms.html
+++ b/cn/gallery/prisms.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/rainbows.html
+++ b/cn/gallery/rainbows.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/ray-relaying.html
+++ b/cn/gallery/ray-relaying.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/reflect.html
+++ b/cn/gallery/reflect.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/resonator.html
+++ b/cn/gallery/resonator.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/retroreflectors.html
+++ b/cn/gallery/retroreflectors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/rochester-cloak.html
+++ b/cn/gallery/rochester-cloak.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/sea-mirage.html
+++ b/cn/gallery/sea-mirage.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/single-ray-demo.html
+++ b/cn/gallery/single-ray-demo.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/specular-and-diffuse-reflection.html
+++ b/cn/gallery/specular-and-diffuse-reflection.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/spherical-lens-and-mirror.html
+++ b/cn/gallery/spherical-lens-and-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/telescope.html
+++ b/cn/gallery/telescope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/template.html
+++ b/cn/gallery/template.html
@@ -65,7 +65,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/transverse-and-longitudinal-magnification.html
+++ b/cn/gallery/transverse-and-longitudinal-magnification.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/vanishing-point.html
+++ b/cn/gallery/vanishing-point.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/cn/gallery/zoom-lens.html
+++ b/cn/gallery/zoom-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/GRIN-slab.html
+++ b/gallery/GRIN-slab.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/NL-simulation.html
+++ b/gallery/NL-simulation.html
@@ -68,7 +68,7 @@ Contributor: Wen Zhou
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/aplanatic-points.html
+++ b/gallery/aplanatic-points.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/apparent-depth.html
+++ b/gallery/apparent-depth.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/beam-directors.html
+++ b/gallery/beam-directors.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/beam-expanders.html
+++ b/gallery/beam-expanders.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/bended-pencil.html
+++ b/gallery/bended-pencil.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/black-cat-becomes-white.html
+++ b/gallery/black-cat-becomes-white.html
@@ -68,7 +68,7 @@ Contributors: Victory Science, Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/branched-flow.html
+++ b/gallery/branched-flow.html
@@ -67,7 +67,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/broken-pencil.html
+++ b/gallery/broken-pencil.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/camera-obscura.html
+++ b/gallery/camera-obscura.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/caustics-from-a-reflective-sphere.html
+++ b/gallery/caustics-from-a-reflective-sphere.html
@@ -67,7 +67,7 @@ Contributor: Georg Nadorff
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/chaff-countermeasure.html
+++ b/gallery/chaff-countermeasure.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/chromatic-aberration.html
+++ b/gallery/chromatic-aberration.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/chromatic-dispersion.html
+++ b/gallery/chromatic-dispersion.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/compound-microscope.html
+++ b/gallery/compound-microscope.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/concave-lens.html
+++ b/gallery/concave-lens.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/concave-mirror-wearable-display.html
+++ b/gallery/concave-mirror-wearable-display.html
@@ -67,7 +67,7 @@ Contributor: Rene
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/convex-lens.html
+++ b/gallery/convex-lens.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/dichroic-rbg-splitter-and-combiner.html
+++ b/gallery/dichroic-rbg-splitter-and-combiner.html
@@ -68,7 +68,7 @@ Contributor: James Garrard
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/dichroic-rgb-splitter-and-combiner.html
+++ b/gallery/dichroic-rgb-splitter-and-combiner.html
@@ -51,7 +51,7 @@ Contributor: James Garrard
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
+++ b/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
@@ -68,7 +68,7 @@ Contributor: Jordan Anderson
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/fresnel-lens.html
+++ b/gallery/fresnel-lens.html
@@ -68,7 +68,7 @@ Contributors: Stas Fainer, Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/gan-based-lcd-pixel.html
+++ b/gallery/gan-based-lcd-pixel.html
@@ -68,7 +68,7 @@ Contributor: James Garrard
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/hyperbolic-lens.html
+++ b/gallery/hyperbolic-lens.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/hyperbolic-mirror.html
+++ b/gallery/hyperbolic-mirror.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/images-formed-by-two-mirrors.html
+++ b/gallery/images-formed-by-two-mirrors.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/inferior-mirage.html
+++ b/gallery/inferior-mirage.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/internal-reflection.html
+++ b/gallery/internal-reflection.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/interrogation-room.html
+++ b/gallery/interrogation-room.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/keplerian-telescope.html
+++ b/gallery/keplerian-telescope.html
@@ -67,7 +67,7 @@ Contributor: chuangyu J
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/lens-images.html
+++ b/gallery/lens-images.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/logarithmic-spiral-lens.html
+++ b/gallery/logarithmic-spiral-lens.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/luneburg-lens.html
+++ b/gallery/luneburg-lens.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/maxwell-fisheye-lens.html
+++ b/gallery/maxwell-fisheye-lens.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/maze-solution.html
+++ b/gallery/maze-solution.html
@@ -68,7 +68,7 @@ Contributors: Stas Fainer, Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/minimum-deviation-angle.html
+++ b/gallery/minimum-deviation-angle.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/monochromatic-aberrations.html
+++ b/gallery/monochromatic-aberrations.html
@@ -68,7 +68,7 @@ Contributors: Paul Falstad, Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/newtonian-telescope.html
+++ b/gallery/newtonian-telescope.html
@@ -68,7 +68,7 @@ Contributor: Matteo Ricci Cipolloni
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/optical-cavity.html
+++ b/gallery/optical-cavity.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/parabolic-mirror.html
+++ b/gallery/parabolic-mirror.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/penrose-unilluminable-room.html
+++ b/gallery/penrose-unilluminable-room.html
@@ -68,7 +68,7 @@ Contributors: Vincent Fan, Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/periscope.html
+++ b/gallery/periscope.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/prisms.html
+++ b/gallery/prisms.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/rainbows.html
+++ b/gallery/rainbows.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/ray-relaying.html
+++ b/gallery/ray-relaying.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/reflect.html
+++ b/gallery/reflect.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/resonator.html
+++ b/gallery/resonator.html
@@ -68,7 +68,7 @@ Contributor: Mikhail Kochiev
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/retroreflectors.html
+++ b/gallery/retroreflectors.html
@@ -68,7 +68,7 @@ Contributors: Stas Fainer, Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/rochester-cloak.html
+++ b/gallery/rochester-cloak.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/sea-mirage.html
+++ b/gallery/sea-mirage.html
@@ -67,7 +67,7 @@ Contributor: chuangyu J
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/single-ray-demo.html
+++ b/gallery/single-ray-demo.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/specular-and-diffuse-reflection.html
+++ b/gallery/specular-and-diffuse-reflection.html
@@ -68,7 +68,7 @@ Contributor: Steve Stonebraker
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/spherical-lens-and-mirror.html
+++ b/gallery/spherical-lens-and-mirror.html
@@ -68,7 +68,7 @@ Contributor: Yi-Ting Tu
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/telescope.html
+++ b/gallery/telescope.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/template.html
+++ b/gallery/template.html
@@ -64,7 +64,7 @@ Ray Optics Simulation
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/transverse-and-longitudinal-magnification.html
+++ b/gallery/transverse-and-longitudinal-magnification.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/vanishing-point.html
+++ b/gallery/vanishing-point.html
@@ -68,7 +68,7 @@ Contributor: Stas Fainer
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/gallery/zoom-lens.html
+++ b/gallery/zoom-lens.html
@@ -68,7 +68,7 @@ Contributor: Paul Falstad
 <script src="../thirdparty/jquery.min.js"></script>
 <script src="../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/GRIN-slab.html
+++ b/pl/gallery/GRIN-slab.html
@@ -45,7 +45,9 @@ Symulacja promieni optycznych
 Osoba wnosząca wkład: Stas Fainer
 </p>
 <div class="description">
-<p>Jest to symulacja prostokątnego materiału dielektrycznego o współczynniku załamania \(n(ho) = n_0 \sqrt{1-(\alpha \rho)^2}\), gdzie \(n_0=2\) jest współczynnikiem załamania światła na jego osi centralnej, a \(\rho \)  jest odległością radialną od jego osi centralnej, taką, że \(\alpha=\frac{\sqrt{3}}{2R} \), gdzie \(R=100 \) jest jego promieniem.<br>Górny dielektryk w tej symulacji składa się z cienkich prostokątów dielektrycznych o stałym współczynniku załamania światła, zgodnie z \(n(\rho)\) (skrypt do tworzenia tego dielektryka jest dostępny <a href="https://phydemo.app/ray-optics/gallery/GRIN-slab.py" target="_blank">tutaj</a>), podczas gdy dolny dielektryk jest materiałem gradientowym o współczynniku załamania \(n(ho)\).</p>
+<p>Jest to symulacja prostokątnego materiału dielektrycznego o współczynniku załamania \(n(
+ho) = n_0 \sqrt{1-(\alpha \rho)^2}\), gdzie \(n_0=2\) jest współczynnikiem załamania światła na jego osi centralnej, a \(\rho \)  jest odległością radialną od jego osi centralnej, taką, że \(\alpha=\frac{\sqrt{3}}{2R} \), gdzie \(R=100 \) jest jego promieniem.<br>Górny dielektryk w tej symulacji składa się z cienkich prostokątów dielektrycznych o stałym współczynniku załamania światła, zgodnie z \(n(\rho)\) (skrypt do tworzenia tego dielektryka jest dostępny <a href="https://phydemo.app/ray-optics/gallery/GRIN-slab.py" target="_blank">tutaj</a>), podczas gdy dolny dielektryk jest materiałem gradientowym o współczynniku załamania \(n(
+ho)\).</p>
 </div>
 <p>
 <a href="https://phydemo.app/ray-optics/simulator/?pl#../pl/gallery/GRIN-slab" target="_blank" class="btn btn-success btn-lg">Otwórz w symulatorze</a>
@@ -66,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 </div>
 </div>
 <script src="../../thirdparty/jquery.min.js"></script>
-<script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfillotstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/pl/gallery/NL-simulation.html
+++ b/pl/gallery/NL-simulation.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Wen Zhou
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/aplanatic-points.html
+++ b/pl/gallery/aplanatic-points.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/apparent-depth.html
+++ b/pl/gallery/apparent-depth.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/beam-directors.html
+++ b/pl/gallery/beam-directors.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/beam-expanders.html
+++ b/pl/gallery/beam-expanders.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/bended-pencil.html
+++ b/pl/gallery/bended-pencil.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/black-cat-becomes-white.html
+++ b/pl/gallery/black-cat-becomes-white.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Victory Science, Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/broken-pencil.html
+++ b/pl/gallery/broken-pencil.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/camera-obscura.html
+++ b/pl/gallery/camera-obscura.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/chaff-countermeasure.html
+++ b/pl/gallery/chaff-countermeasure.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/chromatic-aberration.html
+++ b/pl/gallery/chromatic-aberration.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/chromatic-dispersion.html
+++ b/pl/gallery/chromatic-dispersion.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/compound-microscope.html
+++ b/pl/gallery/compound-microscope.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/concave-lens.html
+++ b/pl/gallery/concave-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/convex-lens.html
+++ b/pl/gallery/convex-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/dichroic-rbg-splitter-and-combiner.html
+++ b/pl/gallery/dichroic-rbg-splitter-and-combiner.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: James Garrard
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
+++ b/pl/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Jordan Anderson
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/fresnel-lens.html
+++ b/pl/gallery/fresnel-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer, Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/gan-based-lcd-pixel.html
+++ b/pl/gallery/gan-based-lcd-pixel.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: James Garrard
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/hyperbolic-lens.html
+++ b/pl/gallery/hyperbolic-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/hyperbolic-mirror.html
+++ b/pl/gallery/hyperbolic-mirror.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/images-formed-by-two-mirrors.html
+++ b/pl/gallery/images-formed-by-two-mirrors.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/inferior-mirage.html
+++ b/pl/gallery/inferior-mirage.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/internal-reflection.html
+++ b/pl/gallery/internal-reflection.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/interrogation-room.html
+++ b/pl/gallery/interrogation-room.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/lens-images.html
+++ b/pl/gallery/lens-images.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/logarithmic-spiral-lens.html
+++ b/pl/gallery/logarithmic-spiral-lens.html
@@ -68,7 +68,7 @@ Funkcja współczynnika załamania światła, która wspiera promienie o torach 
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/luneburg-lens.html
+++ b/pl/gallery/luneburg-lens.html
@@ -45,7 +45,8 @@ Symulacja promieni optycznych
 Osoba wnosząca wkład: Stas Fainer
 </p>
 <div class="description">
-<p>Symulacja soczewki Luneburga, która jest sferycznym dielektrykiem o współczynniku załamania światła \(\rho) = \sqrt{n_0-(\frac{\rho}{R})^2} \), gdzie \(n_0=2\) to współczynnik załamania w środku soczewki soczewki, \(R=100\) to promień soczewki, a \(ho\) to odległość od środka soczewki.</p><p>Górny dielektryk składa się z \(N=20\) koncentrycznych soczewek sferycznych o promieniu \(R_i=5(N+1-i)\) i współczynniku załamania światła \(n_i = \sqrt{n_0-(\frac{R_i}{R})^2} \), gdzie \(i=1,...,N\). Jednakże, ponieważ ten symulator oblicza efektywny współczynnik załamania światła elementu optycznego poprzez pomnożenie współczynnika załamania elementu przez współczynniki załamania elementów optycznych, które są w nim osadzone, współczynnik załamania \(i\)-tej koncentrycznej soczewki sferycznej jest określony wzorem \(n_{i}^\text{numerical}=\frac{n_i}{\prod\limits_{k=i+1}^{N}n_k}\).</p><p>Dolny dielektryk jest materiałem gradientowym o współczynniku załamania \(n(r)\).</p>
+<p>Symulacja soczewki Luneburga, która jest sferycznym dielektrykiem o współczynniku załamania światła \(\rho) = \sqrt{n_0-(\frac{\rho}{R})^2} \), gdzie \(n_0=2\) to współczynnik załamania w środku soczewki soczewki, \(R=100\) to promień soczewki, a \(
+ho\) to odległość od środka soczewki.</p><p>Górny dielektryk składa się z \(N=20\) koncentrycznych soczewek sferycznych o promieniu \(R_i=5(N+1-i)\) i współczynniku załamania światła \(n_i = \sqrt{n_0-(\frac{R_i}{R})^2} \), gdzie \(i=1,...,N\). Jednakże, ponieważ ten symulator oblicza efektywny współczynnik załamania światła elementu optycznego poprzez pomnożenie współczynnika załamania elementu przez współczynniki załamania elementów optycznych, które są w nim osadzone, współczynnik załamania \(i\)-tej koncentrycznej soczewki sferycznej jest określony wzorem \(n_{i}^\text{numerical}=\frac{n_i}{\prod\limits_{k=i+1}^{N}n_k}\).</p><p>Dolny dielektryk jest materiałem gradientowym o współczynniku załamania \(n(r)\).</p>
 </div>
 <p>
 <a href="https://phydemo.app/ray-optics/simulator/?pl#../pl/gallery/luneburg-lens" target="_blank" class="btn btn-success btn-lg">Otwórz w symulatorze</a>
@@ -67,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 </div>
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<script asynchttps://cdnjs.cloudflare.com/polyfill/buttons.github.io/buttons.js"></script>
 <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>

--- a/pl/gallery/maxwell-fisheye-lens.html
+++ b/pl/gallery/maxwell-fisheye-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/maze-solution.html
+++ b/pl/gallery/maze-solution.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer, Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/minimum-deviation-angle.html
+++ b/pl/gallery/minimum-deviation-angle.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/monochromatic-aberrations.html
+++ b/pl/gallery/monochromatic-aberrations.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad, Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/newtonian-telescope.html
+++ b/pl/gallery/newtonian-telescope.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Matteo Ricci Cipolloni
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/optical-cavity.html
+++ b/pl/gallery/optical-cavity.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/parabolic-mirror.html
+++ b/pl/gallery/parabolic-mirror.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/penrose-unilluminable-room.html
+++ b/pl/gallery/penrose-unilluminable-room.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Vincent Fan, Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/periscope.html
+++ b/pl/gallery/periscope.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/prisms.html
+++ b/pl/gallery/prisms.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/rainbows.html
+++ b/pl/gallery/rainbows.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/ray-relaying.html
+++ b/pl/gallery/ray-relaying.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/reflect.html
+++ b/pl/gallery/reflect.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/resonator.html
+++ b/pl/gallery/resonator.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Mikhail Kochiev
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/retroreflectors.html
+++ b/pl/gallery/retroreflectors.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer, Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/rochester-cloak.html
+++ b/pl/gallery/rochester-cloak.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/single-ray-demo.html
+++ b/pl/gallery/single-ray-demo.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/specular-and-diffuse-reflection.html
+++ b/pl/gallery/specular-and-diffuse-reflection.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Steve Stonebraker
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/spherical-lens-and-mirror.html
+++ b/pl/gallery/spherical-lens-and-mirror.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Yi-Ting Tu
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/telescope.html
+++ b/pl/gallery/telescope.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/template.html
+++ b/pl/gallery/template.html
@@ -64,7 +64,7 @@ Osoba wnosząca wkład: {CONTRIBUTORS}
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/transverse-and-longitudinal-magnification.html
+++ b/pl/gallery/transverse-and-longitudinal-magnification.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/vanishing-point.html
+++ b/pl/gallery/vanishing-point.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Stas Fainer
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/pl/gallery/zoom-lens.html
+++ b/pl/gallery/zoom-lens.html
@@ -68,7 +68,7 @@ Osoba wnosząca wkład: Paul Falstad
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/GRIN-slab.html
+++ b/tw/gallery/GRIN-slab.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/NL-simulation.html
+++ b/tw/gallery/NL-simulation.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/aplanatic-points.html
+++ b/tw/gallery/aplanatic-points.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/apparent-depth.html
+++ b/tw/gallery/apparent-depth.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/beam-directors.html
+++ b/tw/gallery/beam-directors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/beam-expanders.html
+++ b/tw/gallery/beam-expanders.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/bended-pencil.html
+++ b/tw/gallery/bended-pencil.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/black-cat-becomes-white.html
+++ b/tw/gallery/black-cat-becomes-white.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/branched-flow.html
+++ b/tw/gallery/branched-flow.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/broken-pencil.html
+++ b/tw/gallery/broken-pencil.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/camera-obscura.html
+++ b/tw/gallery/camera-obscura.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/caustics-from-a-reflective-sphere.html
+++ b/tw/gallery/caustics-from-a-reflective-sphere.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/chaff-countermeasure.html
+++ b/tw/gallery/chaff-countermeasure.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/chromatic-aberration.html
+++ b/tw/gallery/chromatic-aberration.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/chromatic-dispersion.html
+++ b/tw/gallery/chromatic-dispersion.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/compound-microscope.html
+++ b/tw/gallery/compound-microscope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/concave-lens.html
+++ b/tw/gallery/concave-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/concave-mirror-wearable-display.html
+++ b/tw/gallery/concave-mirror-wearable-display.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/convex-lens.html
+++ b/tw/gallery/convex-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/dichroic-rbg-splitter-and-combiner.html
+++ b/tw/gallery/dichroic-rbg-splitter-and-combiner.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
+++ b/tw/gallery/einstein-ring-refocused-to-single-image-via-eyepiece.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/fresnel-lens.html
+++ b/tw/gallery/fresnel-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/gan-based-lcd-pixel.html
+++ b/tw/gallery/gan-based-lcd-pixel.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/hyperbolic-lens.html
+++ b/tw/gallery/hyperbolic-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/hyperbolic-mirror.html
+++ b/tw/gallery/hyperbolic-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/images-formed-by-two-mirrors.html
+++ b/tw/gallery/images-formed-by-two-mirrors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/inferior-mirage.html
+++ b/tw/gallery/inferior-mirage.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/internal-reflection.html
+++ b/tw/gallery/internal-reflection.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/interrogation-room.html
+++ b/tw/gallery/interrogation-room.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/keplerian-telescope.html
+++ b/tw/gallery/keplerian-telescope.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/lens-images.html
+++ b/tw/gallery/lens-images.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/logarithmic-spiral-lens.html
+++ b/tw/gallery/logarithmic-spiral-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/luneburg-lens.html
+++ b/tw/gallery/luneburg-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/maxwell-fisheye-lens.html
+++ b/tw/gallery/maxwell-fisheye-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/maze-solution.html
+++ b/tw/gallery/maze-solution.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/minimum-deviation-angle.html
+++ b/tw/gallery/minimum-deviation-angle.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/monochromatic-aberrations.html
+++ b/tw/gallery/monochromatic-aberrations.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/newtonian-telescope.html
+++ b/tw/gallery/newtonian-telescope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/optical-cavity.html
+++ b/tw/gallery/optical-cavity.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/parabolic-mirror.html
+++ b/tw/gallery/parabolic-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/penrose-unilluminable-room.html
+++ b/tw/gallery/penrose-unilluminable-room.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/periscope.html
+++ b/tw/gallery/periscope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/prisms.html
+++ b/tw/gallery/prisms.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/rainbows.html
+++ b/tw/gallery/rainbows.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/ray-relaying.html
+++ b/tw/gallery/ray-relaying.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/reflect.html
+++ b/tw/gallery/reflect.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/resonator.html
+++ b/tw/gallery/resonator.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/retroreflectors.html
+++ b/tw/gallery/retroreflectors.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/rochester-cloak.html
+++ b/tw/gallery/rochester-cloak.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/sea-mirage.html
+++ b/tw/gallery/sea-mirage.html
@@ -68,7 +68,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/single-ray-demo.html
+++ b/tw/gallery/single-ray-demo.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/specular-and-diffuse-reflection.html
+++ b/tw/gallery/specular-and-diffuse-reflection.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/spherical-lens-and-mirror.html
+++ b/tw/gallery/spherical-lens-and-mirror.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/telescope.html
+++ b/tw/gallery/telescope.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/template.html
+++ b/tw/gallery/template.html
@@ -65,7 +65,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/transverse-and-longitudinal-magnification.html
+++ b/tw/gallery/transverse-and-longitudinal-magnification.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/vanishing-point.html
+++ b/tw/gallery/vanishing-point.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/tw/gallery/zoom-lens.html
+++ b/tw/gallery/zoom-lens.html
@@ -69,7 +69,7 @@
 <script src="../../thirdparty/jquery.min.js"></script>
 <script src="../../thirdparty/bootstrap-3.3.7/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Many `ray-optics` loads polyfill from `polyfill.io` in order to load the MathJax. The PR replaces `polyfill.io` with `cdnjs.cloudflare.com/polyfill`.

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.
