### PR TITLE
Rotate/translate sliders for line segments

### DIFF
--- a/simulator/js/ObjBar.js
+++ b/simulator/js/ObjBar.js
@@ -116,6 +116,7 @@ class ObjBar {
     objOption_text.onclick = function (e) {
       this.select();
     };
+    return objOption_text;
   }
 
 

--- a/simulator/js/geometry.js
+++ b/simulator/js/geometry.js
@@ -208,6 +208,20 @@ var geometry = {
   },
 
   /**
+   * Calculate the normal vector of a segment.
+   * @param {Point} p1
+   * @param {Point} p2
+   * @return {Point}
+   */
+  normalVector: function (p1, p2) {
+    var dx = p2.x - p1.x;
+    var dy = p2.y - p1.y;
+    var length = Math.sqrt(dx * dx + dy * dy);
+
+    return geometry.point(dy / length, -dx / length);
+  },
+
+  /**
    * Calculate the perpendicular bisector of a segment.
    * @param {Line} l1
    * @return {Line}
@@ -235,5 +249,49 @@ var geometry = {
     var dx = l1.p2.x - l1.p1.x;
     var dy = l1.p2.y - l1.p1.y;
     return geometry.line(p1, geometry.point(p1.x + dx, p1.y + dy));
-  }
+  },
+
+  /**
+   * Rotate two points around a center point to a specific angle. If a center point is not provided,
+   * it is assumed to be the midpoint of the segment defined by the two points.
+   * @param {Point} p1
+   * @param {Point} p2
+   * @param {Number} angle - The target angle of the line segment relative to the horizontal axis in radians.
+   * @param {Point} [center] - The center of rotation.
+   * @return {Point[]}
+   */
+  rotatePointsToAngle: function (p1, p2, angle, center) {
+    // If no center is provided, use the midpoint of p1 and p2
+    if (!center) {
+      center = geometry.midpoint(p1, p2);
+    }
+
+    // Calculate the distance between the points and the center
+    var distance = geometry.distance(p1, center);
+
+    // Calculate the new positions of the points at the specified angle
+    var p1_new = geometry.point(center.x - distance * Math.cos(angle), center.y - distance * Math.sin(angle));
+    var p2_new = geometry.point(center.x + distance * Math.cos(angle), center.y + distance * Math.sin(angle));
+
+    return [p1_new, p2_new];
+  },
+
+  /**
+   * Calculate the current angle between two points relative to the horizontal axis.
+   * @param {Point} p1 - The first point.
+   * @param {Point} p2 - The second point.
+   * @return {Number} - The angle in radians.
+   */
+  angleBetweenPoints: function (p1, p2) {
+    var dx = p2.x - p1.x;
+    var dy = p2.y - p1.y;
+    var angle = Math.atan2(dy, dx);
+
+    // Ensure the angle is in the range [0, 2 * Math.PI)
+    if (angle < 0) {
+      angle += 2 * Math.PI;
+    }
+
+    return angle;
+  },
 };

--- a/simulator/js/objs/LineObjMixin.js
+++ b/simulator/js/objs/LineObjMixin.js
@@ -135,7 +135,11 @@ const LineObjMixin = Base => class extends Base {
       // If the lens is a point, don't show any other options
       return;
     }
+
     // Store the initial positions of p1 and p2
+    // FIXME: there's a bug here: if the object is moved while the
+    // object bar is open, the initial positions will be wrong.
+    // many possible solutions...
     var initialP1 = Object.assign({}, this.p1);
     var initialP2 = Object.assign({}, this.p2);
     // Calculate the normal vector

--- a/simulator/js/objs/glass/IdealLens.js
+++ b/simulator/js/objs/glass/IdealLens.js
@@ -15,6 +15,7 @@ objTypes['IdealLens'] = class extends LineObjMixin(BaseSceneObj) {
   };
 
   populateObjBar(objBar) {
+    super.populateObjBar(objBar);
     objBar.createNumber(getMsg('focalLength'), -1000 * this.scene.lengthScale, 1000 * this.scene.lengthScale, 1 * this.scene.lengthScale, this.focalLength, function (obj, value) {
       obj.focalLength = value;
     }, getMsg('length_unit_popover'));


### PR DESCRIPTION
hey @ricktu288 and thanks for this great tool.  I'm opening a PR rather than a discussion just to provide some concrete examples, but i expect this to require discussion.

One thing I often want to do when teaching is to show how the system changes when one component gets translated/rotated.  This is of course possible with clicking and dragging, but I wasn't able to find a way to move both points of a line segment in a restricted way, for example, to rotate a mirror around the midpoint, or to translate a lens along it's normal vector/optical axis.   There are often too many unconstrained degrees of freedom, I wanted to do something like this:


https://github.com/user-attachments/assets/22c7e6ce-53ef-4a3a-8ffd-782802f06b5e

or this:

https://github.com/user-attachments/assets/c5bb66fd-04e0-4192-819e-5342016b8865


This PR is an example that adds sliders to the `LineObjMixin` ... but I'd be more than happy to move that functionality elswhere if you generally like the concept, but don't like the UI.  For example, I can imagine adding a "rotate" handle, or some sort of normal-vector handle that strictly translates a component along its normal

Or, if what I'm trying to do is already possible in a different way, feel free to let me know :)
