### PR TITLE
Fix Aperture key and translations

### DIFF
--- a/locales/de/simulator.json
+++ b/locales/de/simulator.json
@@ -145,7 +145,7 @@
         "units": "Einheiten - [Länge]."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Durchmesser"
     },
     "DiffractionGrating": {

--- a/locales/en/simulator.json
+++ b/locales/en/simulator.json
@@ -211,7 +211,7 @@
         "functions": "This numerical tolerance is used in the functions 'isOnBoundary' and 'countIntersections', inside the 'GrinGlass.js' file."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Diameter"
     },
     "DiffractionGrating": {

--- a/locales/es/simulator.json
+++ b/locales/es/simulator.json
@@ -157,7 +157,7 @@
         "functions": "Esta tolerancia numérica se usa en las funciones 'isOnBoundary' y 'countIntersections', dentro del archivo 'GrinGlass.js'."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Diámetro"
     },
     "Detector": {

--- a/locales/km/simulator.json
+++ b/locales/km/simulator.json
@@ -138,7 +138,7 @@
         "units": "ខ្នាត - [length]។"
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "អង្កត់ផ្ចិត"
     },
     "Ruler": {

--- a/locales/pl/simulator.json
+++ b/locales/pl/simulator.json
@@ -209,7 +209,7 @@
         "functions": "Ta tolerancja numeryczna jest używana w funkcjach 'isOnBoundary' i 'countIntersections' w pliku 'GrinGlass.js'."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Średnica"
     },
     "DiffractionGrating": {

--- a/locales/pt-BR/simulator.json
+++ b/locales/pt-BR/simulator.json
@@ -211,7 +211,7 @@
         "functions": "Essa tolerância numérica é usada nas funções 'isOnBoundary' e 'countIntersections', dentro do arquivo'GrinGlass.js'."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Diâmetro"
     },
     "DiffractionGrating": {

--- a/locales/ru/simulator.json
+++ b/locales/ru/simulator.json
@@ -190,7 +190,7 @@
       "stepSize": "Размер шага численного решателя",
       "symbolicBodyMerging": "Символическое слияние тел"
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "Диаметр"
     },
     "DiffractionGrating": {

--- a/locales/si/simulator.json
+++ b/locales/si/simulator.json
@@ -128,7 +128,7 @@
         "focalDistances": "නාභීය දුර"
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "විෂ්කම්භය"
     },
     "DiffractionGrating": {

--- a/locales/ta/simulator.json
+++ b/locales/ta/simulator.json
@@ -211,7 +211,7 @@
         "functions": "இந்த எண் சகிப்புத்தன்மை 'isonboundary' மற்றும் 'CountEntersections' செயல்பாடுகளில், 'gringlass.js' கோப்பில் பயன்படுத்தப்படுகிறது."
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "விட்டம்"
     },
     "DiffractionGrating": {

--- a/locales/zh-CN/simulator.json
+++ b/locales/zh-CN/simulator.json
@@ -211,7 +211,7 @@
         "functions": "本数值容忍度被用于 'GrinGlass.js' 中的 'isOutsideGlass', 'isInsideGlass' 以及 'isOnBoundary' 函数。"
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "直径"
     },
     "DiffractionGrating": {

--- a/locales/zh-TW/simulator.json
+++ b/locales/zh-TW/simulator.json
@@ -211,7 +211,7 @@
         "functions": "本數值容忍度被用於 'GrinGlass.js' 中的 'isOutsideGlass', 'isInsideGlass' 以及 'isOnBoundary' 函數。"
       }
     },
-    "Aperature": {
+    "Aperture": {
       "diameter": "直徑"
     },
     "DiffractionGrating": {

--- a/src/core/sceneObjs/blocker/Aperture.js
+++ b/src/core/sceneObjs/blocker/Aperture.js
@@ -54,7 +54,7 @@ class Aperture extends BaseFilter {
 
     var originalDiameter = geometry.distance(this.p3, this.p4);
 
-    objBar.createNumber(i18next.t('simulator:sceneObjs.Aperature.diameter'), 0, 100 * this.scene.lengthScale, 1 * this.scene.lengthScale, originalDiameter, function (obj, value) {
+    objBar.createNumber(i18next.t('simulator:sceneObjs.Aperture.diameter'), 0, 100 * this.scene.lengthScale, 1 * this.scene.lengthScale, originalDiameter, function (obj, value) {
       var t = 0.5 * (1 - value / geometry.distance(obj.p1, obj.p2));
       obj.p3 = geometry.point(obj.p1.x * (1 - t) + obj.p2.x * t, obj.p1.y * (1 - t) + obj.p2.y * t);
       obj.p4 = geometry.point(obj.p1.x * t + obj.p2.x * (1 - t), obj.p1.y * t + obj.p2.y * (1 - t));

--- a/test/sceneObjs/blocker/Aperture.test.js
+++ b/test/sceneObjs/blocker/Aperture.test.js
@@ -139,7 +139,7 @@ describe('Aperture', () => {
   it('sets aperture diameter', () => {
     user.click(100, 100);
     user.click(200, 200);
-    user.set("{{simulator:sceneObjs.Aperature.diameter}}", 50);
+    user.set("{{simulator:sceneObjs.Aperture.diameter}}", 50);
 
     const p3 = obj.serialize().p3;
     const p4 = obj.serialize().p4;
@@ -159,7 +159,7 @@ describe('Aperture', () => {
       p3: { x: 200, y: 200 },
       p4: { x: 100, y: 100 }
     });
-    expect(user.get("{{simulator:sceneObjs.Aperature.diameter}}")).toBeCloseTo(141.4, 1); // sqrt(2) * 100
+    expect(user.get("{{simulator:sceneObjs.Aperture.diameter}}")).toBeCloseTo(141.4, 1); // sqrt(2) * 100
   });
 
   it('drags p4 with mouse and updates diameter', () => {
@@ -174,6 +174,6 @@ describe('Aperture', () => {
       p3: { x: 200, y: 200 },
       p4: { x: 100, y: 100 }
     });
-    expect(user.get("{{simulator:sceneObjs.Aperature.diameter}}")).toBeCloseTo(141.4, 1); // sqrt(2) * 100
+    expect(user.get("{{simulator:sceneObjs.Aperture.diameter}}")).toBeCloseTo(141.4, 1); // sqrt(2) * 100
   });
 }); 


### PR DESCRIPTION
## Summary
- correct the translation key used for aperture diameter
- rename `Aperature` translation sections to `Aperture`
- update Aperture tests to use the corrected key

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4b577d04832ebc580b3307d62945