### PR TITLE
Fix bodyMerging property typo

### DIFF
--- a/src/core/sceneObjs/glass/CustomGlass.js
+++ b/src/core/sceneObjs/glass/CustomGlass.js
@@ -257,7 +257,7 @@ class CustomGlass extends LineObjMixin(BaseGlass) {
       };
     }
 
-    return this.refract(ray, rayIndex, incidentPoint, incidentData.normal, n1, surfaceMergingObjs, ray.bodyMergingthis);
+    return this.refract(ray, rayIndex, incidentPoint, incidentData.normal, n1, surfaceMergingObjs, ray.bodyMergingObj);
   }
 
   getIncidentData(ray) {

--- a/src/core/sceneObjs/glass/Glass.js
+++ b/src/core/sceneObjs/glass/Glass.js
@@ -465,7 +465,7 @@ class Glass extends BaseGlass {
       };
     }
 
-    return this.refract(ray, rayIndex, incidentPoint, incidentData.normal, n1, surfaceMergingObjs, ray.bodyMergingthis);
+    return this.refract(ray, rayIndex, incidentPoint, incidentData.normal, n1, surfaceMergingObjs, ray.bodyMergingObj);
   }
 
   getIncidentType(ray) {


### PR DESCRIPTION
## Summary
- fix typos in Glass and CustomGlass where `bodyMergingObj` property was misspelled

## Testing
- `npm run test:sceneObjs` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4b6c3d84832e97527cd1710a54ce